### PR TITLE
fix(deps): resolve PostCSS XSS vulnerability via npm overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5141,34 +5141,6 @@
         }
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
@@ -5437,10 +5409,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
     "eslint-config-next": "16.1.1",
     "tailwindcss": "^4",
     "typescript": "^5"
+  },
+  "overrides": {
+    "postcss": "^8.5.10"
   }
 }


### PR DESCRIPTION
## Summary
Resolves PostCSS XSS vulnerability (CVE) via npm overrides by forcing PostCSS 8.5.10+.

## Problem
- PostCSS 8.4.31 contains an unescaped `</style>` XSS vulnerability
- Next.js 16.2.3 pins postcss@8.4.31
- Tailwind 4.1.18 allows postcss@^8.4.41 (still vulnerable)
- Both constraints prevent automatic patching

## Solution
Added npm overrides field to package.json:
```json
"overrides": {
  "postcss": "^8.5.10"
}
```

This forces all dependencies to use PostCSS 8.5.13 (patched version) while maintaining compatibility with existing packages. PostCSS 8.5.x is a bugfix release with no breaking changes.

## Verification
- ✅ npm install resolves to postcss@8.5.13
- ✅ Both Next.js and Tailwind work seamlessly
- ✅ No TypeScript or ESLint errors
- ✅ XSS vulnerability eliminated